### PR TITLE
Quota management and Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,54 @@
+name: "Build and Push Docker Image"
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  docker-build:
+    name: "Build & push Docker image"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Generate timestamp tag
+        id: timestamp
+        run: |
+          # Generate YYYY-MM-DD.milliseconds format
+          # %s gives Unix epoch seconds, %3N gives nanoseconds truncated to 3 digits (milliseconds)
+          TIMESTAMP=$(date -u +"%Y-%m-%d.%s%3N")
+          # Result: 2024-01-15.1705312345123 (date + epoch milliseconds)
+          echo "tag=${TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "Generated tag: ${TIMESTAMP}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          push: true
+          tags: |
+            nellcorp/maddy:${{ steps.timestamp.outputs.tag }}
+            nellcorp/maddy:latest
+          labels: |
+            org.opencontainers.image.title=Maddy Mail Server
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/api.go
+++ b/api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/foxcpp/maddy/framework/module"
 	"github.com/foxcpp/maddy/internal/rest/util/server"
+	"github.com/foxcpp/maddy/internal/storage/imapsql"
 
 	"github.com/foxcpp/maddy/internal/rest/util/middleware/basic_auth"
 )
@@ -37,6 +38,11 @@ func startApi(globals map[string]interface{}, mods []ModInfo, wg *sync.WaitGroup
 	}
 
 	defer closeIfNeeded(imapDb)
+
+	// Initialize domain_quotas table
+	if err := initDomainQuotasTable(); err != nil {
+		log.Printf("Warning: failed to initialize domain_quotas table: %v", err)
+	}
 
 	if os.Getenv("ADMIN_EMAIL") == "" || os.Getenv("ADMIN_PASSWORD") == "" {
 		log.Fatal("ADMIN_EMAIL and ADMIN_PASSWORD environment variables must be set")
@@ -70,12 +76,20 @@ func NewV1(e *echo.Echo) {
 		users.GET("/:id", getUser)
 		users.POST("/:id/password", updateUserPassword)
 		users.DELETE("/:id", deleteUser)
+		users.GET("/:id/quota", getUserQuota)
+		users.PUT("/:id/quota", setUserQuota)
 	}
 
 	mailboxes := v1.Group("/users/:id/mailboxes")
 	{
 		mailboxes.POST("", createImapAccount)
 		mailboxes.DELETE("", deleteImapAccount)
+	}
+
+	domains := v1.Group("/domains")
+	{
+		domains.GET("/:domain/quota", getDomainQuota)
+		domains.PUT("/:domain/quota", setDomainQuota)
 	}
 }
 
@@ -85,4 +99,39 @@ func healthCheck(c echo.Context) error {
 
 func version(c echo.Context) error {
 	return c.JSON(http.StatusOK, Version)
+}
+
+// initQuotaTables creates the quota tables if they don't exist
+func initDomainQuotasTable() error {
+	storage, ok := imapDb.(*imapsql.Storage)
+	if !ok {
+		return nil // Not using imapsql backend, skip
+	}
+	db := storage.Back.DB
+
+	// Create domain_quotas table
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS domain_quotas (
+			id BIGSERIAL PRIMARY KEY,
+			domain VARCHAR(255) NOT NULL UNIQUE,
+			quota_bytes BIGINT NOT NULL DEFAULT 0,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return err
+	}
+
+	// Create user_quotas table for user-specific overrides
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS user_quotas (
+			id BIGSERIAL PRIMARY KEY,
+			username VARCHAR(255) NOT NULL UNIQUE,
+			quota_bytes BIGINT NOT NULL DEFAULT 0,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	return err
 }

--- a/internal/rest/model/quota.go
+++ b/internal/rest/model/quota.go
@@ -1,0 +1,38 @@
+package model
+
+// UserQuotaResponse represents quota information for a single user
+type UserQuotaResponse struct {
+	Username    string         `json:"username"`
+	UsedBytes   int64          `json:"usedBytes"`
+	QuotaBytes  int64          `json:"quotaBytes"`  // 0 = unlimited
+	QuotaSource string         `json:"quotaSource"` // "user", "domain", or "none"
+	Mailboxes   []MailboxUsage `json:"mailboxes"`
+}
+
+// MailboxUsage represents storage usage for a single mailbox
+type MailboxUsage struct {
+	Name         string `json:"name"`
+	MessageCount int64  `json:"messageCount"`
+	UsedBytes    int64  `json:"usedBytes"`
+}
+
+// DomainQuotaResponse represents quota information for a domain
+type DomainQuotaResponse struct {
+	Domain     string      `json:"domain"`
+	UsedBytes  int64       `json:"usedBytes"`
+	QuotaBytes int64       `json:"quotaBytes"` // 0 = unlimited
+	UserCount  int64       `json:"userCount"`
+	Users      []UserUsage `json:"users"`
+}
+
+// UserUsage represents storage usage for a user within a domain
+type UserUsage struct {
+	Username      string `json:"username"`
+	UsedBytes     int64  `json:"usedBytes"`
+	QuotaOverride *int64 `json:"quotaOverride,omitempty"` // nil if using domain quota
+}
+
+// SetQuotaRequest is the request body for setting quota limits
+type SetQuotaRequest struct {
+	QuotaBytes int64 `json:"quotaBytes" validate:"gte=0"`
+}

--- a/internal/storage/imapsql/quota.go
+++ b/internal/storage/imapsql/quota.go
@@ -1,0 +1,78 @@
+/*
+Maddy Mail Server - Composable all-in-one email server.
+Copyright 2019-2020 Max Mazurov <fox.cpp@disroot.org>, Maddy Mail Server contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package imapsql
+
+import (
+	"database/sql"
+
+	"github.com/foxcpp/maddy/framework/exterrors"
+)
+
+// CheckQuota verifies if the user has enough quota for a new message.
+// additionalBytes is the size of the incoming message (0 for pre-check).
+// Returns an SMTP error if quota is exceeded, nil otherwise.
+func (store *Storage) CheckQuota(username string, additionalBytes int64) error {
+	db := store.Back.DB
+
+	// Query current usage and effective quota
+	// Effective quota: user_quotas > domain_quotas > unlimited (0)
+	var usedBytes int64
+	var effectiveQuota int64
+
+	err := db.QueryRow(`
+		SELECT
+			COALESCE(SUM(m.bodylen), 0),
+			COALESCE(
+				(SELECT quota_bytes FROM user_quotas WHERE username = u.username),
+				(SELECT quota_bytes FROM domain_quotas
+				 WHERE domain = SUBSTRING(u.username FROM POSITION('@' IN u.username) + 1)),
+				0
+			)
+		FROM users u
+		LEFT JOIN mboxes mb ON mb.uid = u.id
+		LEFT JOIN msgs m ON m.mboxid = mb.id
+		WHERE u.username = $1
+		GROUP BY u.id, u.username
+	`, username).Scan(&usedBytes, &effectiveQuota)
+
+	if err == sql.ErrNoRows {
+		// User doesn't exist yet, let other checks handle it
+		return nil
+	}
+	if err != nil {
+		store.Log.Error("quota check failed", err, "username", username)
+		return err
+	}
+
+	// 0 means unlimited
+	if effectiveQuota == 0 {
+		return nil
+	}
+
+	if usedBytes+additionalBytes > effectiveQuota {
+		return &exterrors.SMTPError{
+			Code:         552,
+			EnhancedCode: exterrors.EnhancedCode{5, 2, 2},
+			Message:      "Mailbox quota exceeded",
+			TargetName:   "imapsql",
+		}
+	}
+
+	return nil
+}

--- a/quota.go
+++ b/quota.go
@@ -1,0 +1,260 @@
+package maddy
+
+import (
+	"database/sql"
+	"net/http"
+	"strings"
+
+	"github.com/foxcpp/maddy/internal/rest/model"
+	"github.com/foxcpp/maddy/internal/storage/imapsql"
+	echo "github.com/labstack/echo/v4"
+)
+
+// getUserQuota handles GET /v1/users/:id/quota
+func getUserQuota(c echo.Context) error {
+	username := c.Param("id")
+
+	storage, ok := imapDb.(*imapsql.Storage)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "storage backend not accessible")
+	}
+	db := storage.Back.DB
+
+	// Get mailbox breakdown
+	mailboxQuery := `
+		SELECT mb.name, COUNT(m.msgid), COALESCE(SUM(m.bodylen), 0)
+		FROM mboxes mb
+		LEFT JOIN msgs m ON m.mboxid = mb.id
+		WHERE mb.uid = (SELECT id FROM users WHERE username = $1)
+		GROUP BY mb.id, mb.name
+		ORDER BY mb.name
+	`
+
+	rows, err := db.Query(mailboxQuery, username)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var mailboxes []model.MailboxUsage
+	var totalUsed int64
+
+	for rows.Next() {
+		var mu model.MailboxUsage
+		if err := rows.Scan(&mu.Name, &mu.MessageCount, &mu.UsedBytes); err != nil {
+			return err
+		}
+		totalUsed += mu.UsedBytes
+		mailboxes = append(mailboxes, mu)
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// If no mailboxes found, check if user exists
+	if len(mailboxes) == 0 {
+		var exists bool
+		err := db.QueryRow("SELECT EXISTS(SELECT 1 FROM users WHERE username = $1)", username).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return c.NoContent(http.StatusNotFound)
+		}
+	}
+
+	// Get quota info (user override or domain quota)
+	domain := extractDomain(username)
+	var userQuota, domainQuota sql.NullInt64
+
+	err = db.QueryRow("SELECT quota_bytes FROM user_quotas WHERE username = $1", username).Scan(&userQuota)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	err = db.QueryRow("SELECT quota_bytes FROM domain_quotas WHERE domain = $1", domain).Scan(&domainQuota)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	// Determine effective quota and source
+	var quotaBytes int64
+	var quotaSource string
+
+	if userQuota.Valid && userQuota.Int64 > 0 {
+		quotaBytes = userQuota.Int64
+		quotaSource = "user"
+	} else if domainQuota.Valid && domainQuota.Int64 > 0 {
+		quotaBytes = domainQuota.Int64
+		quotaSource = "domain"
+	} else {
+		quotaBytes = 0
+		quotaSource = "none"
+	}
+
+	response := model.UserQuotaResponse{
+		Username:    username,
+		UsedBytes:   totalUsed,
+		QuotaBytes:  quotaBytes,
+		QuotaSource: quotaSource,
+		Mailboxes:   mailboxes,
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// setUserQuota handles PUT /v1/users/:id/quota
+func setUserQuota(c echo.Context) error {
+	username := c.Param("id")
+
+	var req model.SetQuotaRequest
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	storage, ok := imapDb.(*imapsql.Storage)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "storage backend not accessible")
+	}
+	db := storage.Back.DB
+
+	// Check if user exists
+	var exists bool
+	err := db.QueryRow("SELECT EXISTS(SELECT 1 FROM users WHERE username = $1)", username).Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return c.NoContent(http.StatusNotFound)
+	}
+
+	// Upsert user quota override
+	_, err = db.Exec(`
+		INSERT INTO user_quotas (username, quota_bytes, updated_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)
+		ON CONFLICT (username) DO UPDATE SET
+			quota_bytes = EXCLUDED.quota_bytes,
+			updated_at = CURRENT_TIMESTAMP
+	`, username, req.QuotaBytes)
+
+	if err != nil {
+		return err
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// getDomainQuota handles GET /v1/domains/:domain/quota
+func getDomainQuota(c echo.Context) error {
+	domain := c.Param("domain")
+
+	storage, ok := imapDb.(*imapsql.Storage)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "storage backend not accessible")
+	}
+	db := storage.Back.DB
+
+	// Get domain quota setting
+	var quotaBytes int64
+	err := db.QueryRow("SELECT quota_bytes FROM domain_quotas WHERE domain = $1", domain).Scan(&quotaBytes)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	// Get per-user breakdown
+	userQuery := `
+		SELECT u.username, COALESCE(SUM(m.bodylen), 0), uq.quota_bytes
+		FROM users u
+		LEFT JOIN mboxes mb ON mb.uid = u.id
+		LEFT JOIN msgs m ON m.mboxid = mb.id
+		LEFT JOIN user_quotas uq ON uq.username = u.username
+		WHERE u.username LIKE '%@' || $1
+		GROUP BY u.id, u.username, uq.quota_bytes
+		ORDER BY u.username
+	`
+
+	rows, err := db.Query(userQuery, domain)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var users []model.UserUsage
+	var totalUsed int64
+
+	for rows.Next() {
+		var username string
+		var usedBytes int64
+		var quotaOverride sql.NullInt64
+
+		if err := rows.Scan(&username, &usedBytes, &quotaOverride); err != nil {
+			return err
+		}
+
+		user := model.UserUsage{
+			Username:  username,
+			UsedBytes: usedBytes,
+		}
+		if quotaOverride.Valid && quotaOverride.Int64 > 0 {
+			user.QuotaOverride = &quotaOverride.Int64
+		}
+
+		totalUsed += usedBytes
+		users = append(users, user)
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	response := model.DomainQuotaResponse{
+		Domain:     domain,
+		UsedBytes:  totalUsed,
+		QuotaBytes: quotaBytes,
+		UserCount:  int64(len(users)),
+		Users:      users,
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// setDomainQuota handles PUT /v1/domains/:domain/quota
+func setDomainQuota(c echo.Context) error {
+	domain := c.Param("domain")
+
+	var req model.SetQuotaRequest
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	storage, ok := imapDb.(*imapsql.Storage)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "storage backend not accessible")
+	}
+	db := storage.Back.DB
+
+	// Upsert domain quota
+	_, err := db.Exec(`
+		INSERT INTO domain_quotas (domain, quota_bytes, updated_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)
+		ON CONFLICT (domain) DO UPDATE SET
+			quota_bytes = EXCLUDED.quota_bytes,
+			updated_at = CURRENT_TIMESTAMP
+	`, domain, req.QuotaBytes)
+
+	if err != nil {
+		return err
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// extractDomain extracts the domain part from an email address
+func extractDomain(email string) string {
+	parts := strings.Split(email, "@")
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Implement comprehensive quota management with per-user and per-domain quotas
- Add REST API endpoints for quota reporting and configuration (GET/PUT)
- Enforce quotas on SMTP delivery with 552 rejection when over limit
- Create separate GitHub Actions workflow for timestamped Docker image builds supporting amd64 and arm64

## Files Changed

New files: quota.go, internal/rest/model/quota.go, internal/storage/imapsql/quota.go, .github/workflows/docker-build.yml
Modified: api.go, delivery.go, CLAUDE.md, architecture.md

## Implementation Details

Quota hierarchy: user_quotas > domain_quotas > unlimited (0). Quotas calculated using msgs.bodylen for storage usage. New tables created automatically on startup.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quota management system with REST API endpoints for per-user and per-domain quotas
  * Quota enforcement during email delivery to prevent exceeding limits
  * Docker image build automation for multi-architecture deployments

* **Documentation**
  * Updated documentation reflecting quota management capabilities and API endpoints

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->