### PR TITLE
ci: trigger docker build on push to main

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: "Build and Push Docker Image"
 on:
   push:
     branches:
-      - bantumail
+      - main
 
 jobs:
   docker-build:


### PR DESCRIPTION
Retarget the **Build and Push Docker Image** workflow trigger from `bantumail` to `main`, now the primary branch.

Single-line change in `.github/workflows/docker-build.yml`. Takes effect once merged (workflow triggers on `push` to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)