### PR TITLE
Make REST API port configurable via MADDY_PORT

### DIFF
--- a/api.go
+++ b/api.go
@@ -52,12 +52,17 @@ func startApi(mods []ModInfo, wg *sync.WaitGroup) (err error) {
 		os.Exit(1)
 	}
 
+	port := os.Getenv("MADDY_PORT")
+	if port == "" {
+		port = "8080"
+	}
+
 	e := server.New()
 
 	NewV1(e)
 
 	server.Start(e, &server.Config{
-		Port:                "8080",
+		Port:                port,
 		ReadTimeoutSeconds:  30,
 		WriteTimeoutSeconds: 30,
 		Debug:               true,


### PR DESCRIPTION
The REST API port was hardcoded to `8080`. Read it from `MADDY_PORT` (default `8080` when unset) so the daemon can run on a custom port — e.g. alongside other services in local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The server port can now be configured using the `MADDY_PORT` environment variable.
  * If no port is provided, the server continues to use port `8080`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->