### PR TITLE
testutils: drop log lines emitted after the test completes

### DIFF
--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,13 +43,30 @@ func Logger(t *testing.T, name string) log.Logger {
 		}
 	}
 
+	// A server goroutine may emit a log line after the test function has
+	// returned (e.g. an SMTP handler noticing a reset connection). Calling
+	// t.Log then panics with "Log in goroutine after Test... has completed".
+	// Track completion under a mutex and drop such late logs instead.
+	var mu sync.Mutex
+	done := false
+	t.Cleanup(func() {
+		mu.Lock()
+		done = true
+		mu.Unlock()
+	})
+
 	return log.Logger{
 		Out: log.FuncOutput(func(_ time.Time, debug bool, str string) {
-			t.Helper()
 			str = strings.TrimSuffix(str, "\n")
 			if debug {
 				str = "[debug] " + str
 			}
+			mu.Lock()
+			defer mu.Unlock()
+			if done {
+				return
+			}
+			t.Helper()
 			t.Log(str)
 		}, func() error {
 			return nil


### PR DESCRIPTION
## Problem
`Build & test maddy` flakes with:

```
panic: Log in goroutine after TestSubmissionPrepare has completed: smtp: handler error: read tcp ... connection reset by peer
```

A server goroutine (an SMTP submission handler noticing the client reset the connection) emits a log line **after** the test function has returned. `testutils.Logger` routes every line to `t.Log`, and `t.Log` panics when called after the test completes.

## Fix
Track test completion with `t.Cleanup` under a mutex; once the test is done, drop late log lines instead of calling `t.Log`. The mutex serialises with in-flight logs so there's no race between "check done" and `t.Log`.

## Verified
`go test -run TestSubmissionPrepare -race -count=20 ./internal/endpoint/smtp/` → ok (previously panicked intermittently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test logging stability by safely ignoring messages emitted after a test has completed.
  * Prevented late log calls from causing test-related panics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->